### PR TITLE
Displaying content classes in the html

### DIFF
--- a/templates/ticket.html.twig
+++ b/templates/ticket.html.twig
@@ -15,6 +15,7 @@
         <tr><td>Customer</td><td>{{ ticket.customer }}</td></tr>
         <tr><td>Owner</td><td>{{ ticket.owner }}</td></tr>
         <tr><td>Tags</td><td><ul>{% for tag in tags %}<li>{{ tag }}</li>{% endfor %}</ul></td></tr>
+        <tr><td>Content class</td><td><ul>{% for c in ticket.content_class|default([]) %}<li>{{ c }}</li>{% endfor %}</ul></td></tr>
     </table>
     <br>
     <br>


### PR DESCRIPTION
Fixes #14 

Added the content_class to the HTML.

Not using in the path as multiple can be selected.