### PR TITLE
Use response from guzzle exception

### DIFF
--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -69,6 +69,8 @@ class HTTPClient extends Client implements HTTPClientInterface
 
         try {
             $response = parent::request($method, $uri, $options);
+        } catch (\GuzzleHttp\Exception\TransferException $e) {
+            $response = $e->getResponse();
         } catch (\GuzzleHttp\Exception\GuzzleException $e) {
             $response = new Response();
         }


### PR DESCRIPTION
When 500 or 400 a new response is created and code thinks that response was successful but it was not.