### PR TITLE
Replace PDF with HTML in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zammad Ticket Export
 
-This can be used to export tickets from [Zammad](https://zammad.org) to PDF.
-Each ticket will have its own PDF file.
+This can be used to export tickets from [Zammad](https://zammad.org) to HTML.
+Each ticket will have its own HTML file.
 
 This is not intended as a backup or restore solution only intended for archiving tickets.
 


### PR DESCRIPTION
After checking the export script I see that we currently do not export as PDF and only export as HTML and the metadata as json files. 